### PR TITLE
Only allow the author that requested the help command to react

### DIFF
--- a/pretty_help/app_menu.py
+++ b/pretty_help/app_menu.py
@@ -26,10 +26,12 @@ class AppNav(View):
             pages: List[discord.Embed] = None,
             timeout: Optional[float] = None,
             ephemeral: Optional[bool] = False,
+            owner: Optional[int] = None,
     ):
         super().__init__(timeout=timeout)
         self.page_count = len(pages) if pages else None
         self.pages = pages
+        self.ownerID = owner
 
         if pages and len(pages) == 1:
             self.remove_item(self.previous)
@@ -85,8 +87,12 @@ class AppNav(View):
         await interaction.response.edit_message(
             embed=self.pages[self.index % self.page_count], view=self
         )
-
-
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.ownerID:
+            await interaction.response.send_message("Sorry, only the command author can interact with it.", ephemeral=True)
+            return False
+        return True
+    
 class AppMenu(PrettyMenu):
     """
     Navigate pages using the Discord UI components.


### PR DESCRIPTION
The suggested modification ensures that only the author who initiated the help command can interact with the button. This prevents anyone else from deleting or modifying the page of the embed.