### PR TITLE
Only allow the author that requested the help command to react

### DIFF
--- a/pretty_help/app_menu.py
+++ b/pretty_help/app_menu.py
@@ -88,10 +88,7 @@ class AppNav(View):
             embed=self.pages[self.index % self.page_count], view=self
         )
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.allowed_user.id:
-            await interaction.response.send_message("Sorry, only the command author can interact with it.", ephemeral=True)
-            return False
-        return True
+        return interaction.user.id == self.allowed_user.id
 
 class AppMenu(PrettyMenu):
     """

--- a/pretty_help/app_menu.py
+++ b/pretty_help/app_menu.py
@@ -26,12 +26,12 @@ class AppNav(View):
             pages: List[discord.Embed] = None,
             timeout: Optional[float] = None,
             ephemeral: Optional[bool] = False,
-            allower_user: Optional[discord.Member] = None,
+            allowed_user: Optional[discord.Member] = None,
     ):
         super().__init__(timeout=timeout)
         self.page_count = len(pages) if pages else None
         self.pages = pages
-        self.allower_user = allower_user
+        self.allowed_user = allowed_user
 
         if pages and len(pages) == 1:
             self.remove_item(self.previous)

--- a/pretty_help/app_menu.py
+++ b/pretty_help/app_menu.py
@@ -26,10 +26,12 @@ class AppNav(View):
             pages: List[discord.Embed] = None,
             timeout: Optional[float] = None,
             ephemeral: Optional[bool] = False,
+            allower_user: Optional[discord.Member] = None,
     ):
         super().__init__(timeout=timeout)
         self.page_count = len(pages) if pages else None
         self.pages = pages
+        self.allower_user = allower_user
 
         if pages and len(pages) == 1:
             self.remove_item(self.previous)
@@ -85,7 +87,11 @@ class AppNav(View):
         await interaction.response.edit_message(
             embed=self.pages[self.index % self.page_count], view=self
         )
-
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.allowed_user.id:
+            await interaction.response.send_message("Sorry, only the command author can interact with it.", ephemeral=True)
+            return False
+        return True
 
 class AppMenu(PrettyMenu):
     """
@@ -119,11 +125,11 @@ class AppMenu(PrettyMenu):
             await ctx.interaction.response.send_message(
                 embed=pages[0],
                 view=AppNav(
-                    pages=pages, timeout=self.timeout, ephemeral=self.ephemeral
+                    pages=pages, timeout=self.timeout, ephemeral=self.ephemeral, allower_user=ctx.author
                 ),
                 ephemeral=self.ephemeral,
             )
         else:
             await destination.send(
-                embed=pages[0], view=AppNav(pages=pages, timeout=self.timeout)
+                embed=pages[0], view=AppNav(pages=pages, timeout=self.timeout, allower_user=ctx.author)
             )


### PR DESCRIPTION
The suggested modification ensures that only the author who initiated the help command can interact with the button. This prevents anyone else from deleting or modifying the page of the embed.